### PR TITLE
Filter support, test-cleanup and fixes

### DIFF
--- a/py_appsheet/__init__.py
+++ b/py_appsheet/__init__.py
@@ -1,3 +1,4 @@
 from .client import AppSheetClient
+from .utils import build_composite_key, build_selector
 
-__all__ = ["AppSheetClient"]
+__all__ = ["AppSheetClient", "build_composite_key", "build_selector"]

--- a/py_appsheet/utils.py
+++ b/py_appsheet/utils.py
@@ -1,1 +1,46 @@
-#
+def build_composite_key(*values, separator: str = ": ") -> str:
+    """
+    Build an AppSheet composite key matching the default _ComputedKey formula.
+
+    AppSheet constructs composite keys using CONCATENATE([keycol1], ": ", [keycol2], ...)
+    by default. Pass values in the same order as the key columns are defined in the table.
+
+    Args:
+        *values: The key column values, in key-column order.
+        separator (str): The separator between values. Defaults to ": " to match AppSheet's default.
+
+    Returns:
+        str: The composite key string.
+
+    Example:
+        build_composite_key("foo", "bar")  # -> "foo: bar"
+        build_composite_key("a", "b", "c")  # -> "a: b: c"
+    """
+    return separator.join(str(v) for v in values)
+
+
+def build_selector(table_name: str, column: str, value: str, operator: str = "=") -> str:
+    """
+    Build an AppSheet selector expression for use with find_items().
+
+    Constructs a Filter() expression that AppSheet evaluates server-side,
+    avoiding the need to fetch and filter an entire table locally.
+
+    Args:
+        table_name (str): The AppSheet table name (must match exactly).
+        column (str): The column name to filter on.
+        value (str): The value to compare against.
+        operator (str): The comparison operator. Defaults to "=".
+            Common operators: "=", "!=", "<", ">", "<=", ">="
+
+    Returns:
+        str: An AppSheet selector expression string.
+
+    Example:
+        build_selector("Tasks", "Status", "In Progress")
+        # -> "Filter(Tasks, [Status] = 'In Progress')"
+
+        build_selector("Tasks", "Priority", "3", operator=">=")
+        # -> "Filter(Tasks, [Priority] >= '3')"
+    """
+    return f"Filter({table_name}, [{column}] {operator} '{value}')"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: mark test as an integration test requiring real AppSheet credentials (run with: pytest -m integration)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="py-appsheet",
-    version="0.1.0",
+    version="0.2.0",
     description="A no-frills Python library for interacting with the Google AppSheet API.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from dotenv import load_dotenv
+from py_appsheet import AppSheetClient
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: mark test as an integration test requiring real AppSheet credentials"
+    )
+
+
+@pytest.fixture(scope="session")
+def client():
+    load_dotenv()
+    app_id = os.getenv("APP_ID")
+    access_key = os.getenv("ACCESS_KEY")
+    if not app_id or not access_key:
+        pytest.skip("APP_ID and ACCESS_KEY not found in .env — skipping integration tests")
+    return AppSheetClient(app_id=app_id, api_key=access_key)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,127 +1,158 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from py_appsheet.client import AppSheetClient
+from py_appsheet.utils import build_composite_key, build_selector
+
 
 class TestAppSheetClient(unittest.TestCase):
     def setUp(self):
-        self.app_id = "test_app_id"
-        self.api_key = "test_api_key"
-        self.client = AppSheetClient(app_id=self.app_id, api_key=self.api_key)
+        self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
+
+    # --- find_items ---
 
     def test_find_items_found(self):
-        table_name = "Patients"
-        item = "test@example.com"
-        key_column = "Email"
-
-        mock_response = {
-            "Rows": [
-                {"Email": "test@example.com", "Name": "John Doe", "ID": "123"}
-            ]
-        }
-
+        mock_response = [
+            {"Email": "test@example.com", "Name": "John Doe", "ID": "123"}
+        ]
         with patch.object(self.client, '_make_request', return_value=mock_response):
-            result = self.client.find_items(table_name, item, key_column)
-            self.assertEqual(len(result), 1)
-            self.assertEqual(result[0]["Email"], item)
+            result = self.client.find_items("Patients", "test@example.com", target_column="Email")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["Email"], "test@example.com")
 
     def test_find_items_not_found(self):
-        table_name = "Patients"
-        item = "nonexistent@example.com"
-        key_column = "Email"
-
-        mock_response = {
-            "Rows": [
-                {"Email": "test@example.com", "Name": "John Doe", "ID": "123"}
-            ]
-        }
-
+        mock_response = [
+            {"Email": "test@example.com", "Name": "John Doe", "ID": "123"}
+        ]
         with patch.object(self.client, '_make_request', return_value=mock_response):
-            result = self.client.find_items(table_name, item, key_column)
-            self.assertEqual(len(result), 0)
+            result = self.client.find_items("Patients", "nonexistent@example.com", target_column="Email")
+        self.assertEqual(len(result), 0)
 
     def test_find_items_malformed_response(self):
-        table_name = "Patients"
-        item = "test@example.com"
-        key_column = "Email"
-
-        mock_response = {}
-
-        with patch.object(self.client, '_make_request', return_value=mock_response):
-            with self.assertRaises(ValueError) as context:
-                self.client.find_items(table_name, item, key_column)
-            self.assertIn("Unexpected response format or missing 'Rows' key", str(context.exception))
+        with patch.object(self.client, '_make_request', return_value={}):
+            with self.assertRaises(ValueError) as ctx:
+                self.client.find_items("Patients", "test@example.com", target_column="Email")
+        self.assertIn("Expected a list of rows", str(ctx.exception))
 
     def test_find_items_api_error(self):
-        table_name = "Patients"
-        item = "test@example.com"
-        key_column = "Email"
-
         with patch.object(self.client, '_make_request', side_effect=Exception("API Error")):
-            with self.assertRaises(Exception) as context:
-                self.client.find_items(table_name, item, key_column)
-            self.assertIn("API Error", str(context.exception))
+            with self.assertRaises(Exception) as ctx:
+                self.client.find_items("Patients", "test@example.com", target_column="Email")
+        self.assertIn("API Error", str(ctx.exception))
 
     def test_find_items_in_any_column(self):
-        table_name = "Patients"
-        item = "John Doe"
-
-        mock_response = {
-            "Rows": [
-                {"Email": "test@example.com", "Name": "John Doe", "ID": "123"},
-                {"Email": "another@example.com", "Name": "Jane Smith", "ID": "456"}
-            ]
-        }
-
+        mock_response = [
+            {"Email": "test@example.com", "Name": "John Doe", "ID": "123"},
+            {"Email": "another@example.com", "Name": "Jane Smith", "ID": "456"},
+        ]
         with patch.object(self.client, '_make_request', return_value=mock_response):
-            result = self.client.find_items(table_name, item)
-            self.assertEqual(len(result), 1)
-            self.assertEqual(result[0]["Name"], item)
+            result = self.client.find_items("Patients", "John Doe")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["Name"], "John Doe")
+
+    def test_find_items_no_filter_returns_all(self):
+        mock_response = [
+            {"Email": "a@example.com", "Name": "Alice"},
+            {"Email": "b@example.com", "Name": "Bob"},
+        ]
+        with patch.object(self.client, '_make_request', return_value=mock_response):
+            result = self.client.find_items("Patients")
+        self.assertEqual(len(result), 2)
+
+    def test_find_items_with_selector_passes_to_payload(self):
+        mock_response = [{"Status": "In Progress", "ID": "1"}]
+        with patch.object(self.client, '_make_request', return_value=mock_response) as mock_req:
+            result = self.client.find_items("Tasks", selector="Filter(Tasks, [Status] = 'In Progress')")
+        payload = mock_req.call_args[0][2]
+        self.assertEqual(payload["Properties"]["Selector"], "Filter(Tasks, [Status] = 'In Progress')")
+        self.assertEqual(len(result), 1)
+
+    def test_find_items_selector_with_local_filter(self):
+        # Selector narrows server-side; item/target_column refines locally
+        mock_response = [
+            {"Status": "In Progress", "Assignee": "Alice"},
+            {"Status": "In Progress", "Assignee": "Bob"},
+        ]
+        with patch.object(self.client, '_make_request', return_value=mock_response):
+            result = self.client.find_items(
+                "Tasks",
+                item="Alice",
+                target_column="Assignee",
+                selector="Filter(Tasks, [Status] = 'In Progress')",
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["Assignee"], "Alice")
+
+    # --- add_items ---
 
     def test_add_items(self):
-        table_name = "Inventory Table"
-        rows = [
-            {
-                "Generation Date": "1700000000",
-                "UserID": "test@example.com",
-                "Serial Number Hex": "ABC123",
-                "SKU": "SKU123",
-                "Batch": "Batch01",
-            }
-        ]
-
+        rows = [{"Serial Number Hex": "ABC123", "SKU": "SKU123"}]
         mock_response = {"status": "OK"}
-
         with patch.object(self.client, '_make_request', return_value=mock_response):
-            response = self.client.add_items(table_name, rows)
-            self.assertEqual(response["status"], "OK")
+            response = self.client.add_items("Inventory Table", rows)
+        self.assertEqual(response["status"], "OK")
+
+    # --- edit_item ---
 
     def test_edit_item(self):
-        table_name = "Inventory Table"
-        key_column = "Serial Number Hex"
         row_data = {
             "Serial Number Hex": "ABC123",
-            "Bar Code": "Inventory_Images/ABC123_serial_barcode.svg",
-            "QR Code": "Inventory_Images/ABC123_serial_qr.svg"
+            "Bar Code": "some_barcode.svg",
         }
-
         mock_response = {"status": "OK"}
-
         with patch.object(self.client, '_make_request', return_value=mock_response):
-            response = self.client.edit_item(table_name, key_column, row_data)
-            self.assertEqual(response["status"], "OK")
+            response = self.client.edit_item("Inventory Table", "Serial Number Hex", row_data)
+        self.assertEqual(response["status"], "OK")
 
-        def test_delete_row(self):
-            table_name = "Inventory Table"
-            key_column = "Serial Number Hex"
-            key_value = "ABC123"
+    def test_edit_item_missing_key_column_raises(self):
+        row_data = {"Bar Code": "some_barcode.svg"}
+        with self.assertRaises(ValueError) as ctx:
+            self.client.edit_item("Inventory Table", "Serial Number Hex", row_data)
+        self.assertIn("Serial Number Hex", str(ctx.exception))
 
-            mock_response = {"status": "OK"}
+    # --- delete_item / delete_row ---
 
-            with patch.object(self.client, '_make_request', return_value=mock_response):
-                response = self.client.delete_row(table_name, key_column, key_value)
-                self.assertEqual(response["status"], "OK")
+    def test_delete_item(self):
+        mock_response = {"status": "OK"}
+        with patch.object(self.client, '_make_request', return_value=mock_response):
+            response = self.client.delete_item("Inventory Table", "Serial Number Hex", "ABC123")
+        self.assertEqual(response["status"], "OK")
+
+    def test_delete_item_composite_key(self):
+        mock_response = {"status": "OK"}
+        with patch.object(self.client, '_make_request', return_value=mock_response) as mock_req:
+            response = self.client.delete_item("My Table", {"keycol1": "v1", "keycol2": "v2"})
+        payload = mock_req.call_args[0][2]
+        self.assertEqual(payload["Rows"], [{"keycol1": "v1", "keycol2": "v2"}])
+        self.assertEqual(response["status"], "OK")
+
+    def test_delete_row_is_alias_for_delete_item(self):
+        mock_response = {"status": "OK"}
+        with patch.object(self.client, '_make_request', return_value=mock_response):
+            response = self.client.delete_row("Inventory Table", "Serial Number Hex", "ABC123")
+        self.assertEqual(response["status"], "OK")
 
 
+class TestUtils(unittest.TestCase):
+
+    def test_build_composite_key_two_values(self):
+        self.assertEqual(build_composite_key("foo", "bar"), "foo: bar")
+
+    def test_build_composite_key_three_values(self):
+        self.assertEqual(build_composite_key("a", "b", "c"), "a: b: c")
+
+    def test_build_composite_key_custom_separator(self):
+        self.assertEqual(build_composite_key("x", "y", separator="|"), "x|y")
+
+    def test_build_composite_key_non_string_values(self):
+        self.assertEqual(build_composite_key(1, 2), "1: 2")
+
+    def test_build_selector_default_operator(self):
+        result = build_selector("Tasks", "Status", "In Progress")
+        self.assertEqual(result, "Filter(Tasks, [Status] = 'In Progress')")
+
+    def test_build_selector_custom_operator(self):
+        result = build_selector("Tasks", "Priority", "3", operator=">=")
+        self.assertEqual(result, "Filter(Tasks, [Priority] >= '3')")
 
 
 if __name__ == '__main__':

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,168 @@
+"""
+Integration tests against a real AppSheet database.
+
+Requires APP_ID and ACCESS_KEY in a .env file at the project root.
+Run with: pytest -m integration
+
+Tables expected:
+  - example_table: columns "Title Example" (key), "Assignee", "Status", "Date", "Another Column"
+  - dual_key_table: columns "keycol1" (key), "keycol2" (key), "val" (NOT a key)
+      AppSheet composite key column: "_ComputedKey" = "keycol1: keycol2"
+
+NOTE on dual_key_table setup: In AppSheet's column editor, ensure that ONLY
+"keycol1" and "keycol2" have the "Key" checkbox checked. "val" must NOT be a key.
+If all three are marked as keys, _ComputedKey will be a 3-part value and the
+composite key tests will fail.
+"""
+import pytest
+from py_appsheet.utils import build_composite_key, build_selector
+
+EXAMPLE_TABLE = "example_table"
+DUAL_KEY_TABLE = "dual_key_table"
+
+# Sentinel values that identify rows created by these tests
+TEST_TITLE = "pytest_integration_test_row"
+TEST_KEY1 = "pytest_key1"
+TEST_KEY2 = "pytest_key2"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def example_row(client):
+    """Add a test row to example_table and clean up after the test."""
+    row = {
+        "Title Example": TEST_TITLE,
+        "Assignee": "pytest",
+        "Status": "Not Started",
+        "Another Column": "initial value",
+    }
+    client.add_items(EXAMPLE_TABLE, [row])
+    yield row
+    try:
+        client.delete_item(EXAMPLE_TABLE, "Title Example", TEST_TITLE)
+    except Exception:
+        pass  # Already deleted by the test itself
+
+
+@pytest.fixture
+def dual_key_row(client):
+    """Add a test row to dual_key_table and clean up after the test.
+
+    Requires dual_key_table to have keycol1 and keycol2 as keys, val as non-key.
+    """
+    row = {
+        "keycol1": TEST_KEY1,
+        "keycol2": TEST_KEY2,
+        "val": "initial value",
+    }
+    client.add_items(DUAL_KEY_TABLE, [row])
+    yield row
+    try:
+        client.delete_item(DUAL_KEY_TABLE, {"keycol1": TEST_KEY1, "keycol2": TEST_KEY2})
+    except Exception:
+        pass  # Already deleted by the test itself
+
+
+# ---------------------------------------------------------------------------
+# example_table tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestExampleTable:
+
+    def test_add_and_find_local_filter(self, client, example_row):
+        """add_items creates a row that find_items can locate via local filtering."""
+        results = client.find_items(EXAMPLE_TABLE, TEST_TITLE, target_column="Title Example")
+        assert len(results) == 1
+        assert results[0]["Title Example"] == TEST_TITLE
+
+    def test_find_with_selector(self, client, example_row):
+        """find_items with a selector expression returns only matching rows."""
+        selector = build_selector(EXAMPLE_TABLE, "Title Example", TEST_TITLE)
+        results = client.find_items(EXAMPLE_TABLE, selector=selector)
+        assert any(r["Title Example"] == TEST_TITLE for r in results)
+
+    def test_find_no_filter_returns_rows(self, client, example_row):
+        """find_items with no filter returns all rows (at least our test row)."""
+        results = client.find_items(EXAMPLE_TABLE)
+        assert isinstance(results, list)
+        assert len(results) >= 1
+
+    def test_edit_item(self, client, example_row):
+        """edit_item updates a column value on an existing row."""
+        client.edit_item(
+            EXAMPLE_TABLE,
+            "Title Example",
+            {"Title Example": TEST_TITLE, "Another Column": "edited value"},
+        )
+        results = client.find_items(EXAMPLE_TABLE, TEST_TITLE, target_column="Title Example")
+        assert results[0]["Another Column"] == "edited value"
+
+    def test_edit_item_status(self, client, example_row):
+        """edit_item can update an enum column."""
+        client.edit_item(
+            EXAMPLE_TABLE,
+            "Title Example",
+            {"Title Example": TEST_TITLE, "Status": "In Progress"},
+        )
+        results = client.find_items(EXAMPLE_TABLE, TEST_TITLE, target_column="Title Example")
+        assert results[0]["Status"] == "In Progress"
+
+    def test_delete_item(self, client, example_row):
+        """delete_item removes the row; subsequent find returns empty."""
+        client.delete_item(EXAMPLE_TABLE, "Title Example", TEST_TITLE)
+        results = client.find_items(EXAMPLE_TABLE, TEST_TITLE, target_column="Title Example")
+        assert len(results) == 0
+
+    def test_delete_row_alias(self, client, example_row):
+        """delete_row (backwards-compat alias) behaves identically to delete_item."""
+        client.delete_row(EXAMPLE_TABLE, "Title Example", TEST_TITLE)
+        results = client.find_items(EXAMPLE_TABLE, TEST_TITLE, target_column="Title Example")
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# dual_key_table tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestDualKeyTable:
+
+    def test_build_composite_key_format(self):
+        """build_composite_key produces the expected AppSheet _ComputedKey format."""
+        key = build_composite_key(TEST_KEY1, TEST_KEY2)
+        assert key == f"{TEST_KEY1}: {TEST_KEY2}"
+
+    def test_add_and_find_by_composite_key(self, client, dual_key_row):
+        """Rows with composite keys can be found by matching the _ComputedKey column."""
+        expected_key = build_composite_key(TEST_KEY1, TEST_KEY2)
+        results = client.find_items(DUAL_KEY_TABLE, expected_key, target_column="_ComputedKey")
+        assert len(results) == 1
+        assert results[0]["keycol1"] == TEST_KEY1
+        assert results[0]["keycol2"] == TEST_KEY2
+
+    def test_edit_via_composite_key_columns(self, client, dual_key_row):
+        """edit_item works for composite-key tables: include all key columns + updated fields.
+
+        For composite-key tables, pass any one key column as key_column and include
+        ALL key columns plus the fields to update in row_data. AppSheet identifies the
+        row from all key columns present in the row.
+        """
+        client.edit_item(
+            DUAL_KEY_TABLE,
+            "keycol1",
+            {"keycol1": TEST_KEY1, "keycol2": TEST_KEY2, "val": "edited value"},
+        )
+        expected_key = build_composite_key(TEST_KEY1, TEST_KEY2)
+        results = client.find_items(DUAL_KEY_TABLE, expected_key, target_column="_ComputedKey")
+        assert results[0]["val"] == "edited value"
+
+    def test_delete_via_composite_key_dict(self, client, dual_key_row):
+        """delete_item accepts a dict of key column values for composite-key tables."""
+        client.delete_item(DUAL_KEY_TABLE, {"keycol1": TEST_KEY1, "keycol2": TEST_KEY2})
+        expected_key = build_composite_key(TEST_KEY1, TEST_KEY2)
+        results = client.find_items(DUAL_KEY_TABLE, expected_key, target_column="_ComputedKey")
+        assert len(results) == 0


### PR DESCRIPTION
 Changelog for 0.2.0:

  ---
  [0.2.0] - 2026-02-26

  Added

  - find_items() server-side filtering — new optional selector parameter passes an AppSheet Filter() expression to the API, avoiding full-table fetches for large datasets
  - build_selector(table_name, column, value, operator="=") — utility to construct AppSheet selector expressions; importable directly from py_appsheet
  - build_composite_key(*values, separator=": ") — utility to construct _ComputedKey values for composite-key tables; importable directly from py_appsheet
  - delete_item() — cleaner name for delete_row(); also now accepts a dict as the first argument for composite-key tables (e.g. delete_item("Table", {"keycol1": "a", "keycol2": "b"}))
  - Integration test suite (pytest -m integration) with table schema spec in README
  - pytest.ini with integration marker registration

  Changed

  - find_items() item parameter is now optional (defaults to None); omitting it returns all rows (or all selector-filtered rows)
  - README overhauled: corrected method names, added composite key and selector documentation, added testing setup guide

  Fixed

  - Removed orphaned dead docstring in _make_request() (unreachable code after return)
  - Unit tests had wrong mock response format ({"Rows": [...]} dict instead of a bare list), mismatched error message assertion, and test_delete_row was indented inside test_edit_item and never ran

  Deprecated

  - delete_row() — still works, now an alias for delete_item()