### PR TITLE
Allow locale and timezone to be configured on AppSheetClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ client = AppSheetClient(
 )
 ```
 
+`locale` and `timezone` default to `"en-US"` and `"UTC"`. If AppSheet is misinterpreting date values, pass your local settings:
+
+```python
+client = AppSheetClient(
+    app_id=os.environ.get("APPSHEET_APP_ID"),
+    api_key=os.environ.get("APPSHEET_API_KEY"),
+    locale="de-DE",
+    timezone="Europe/Berlin",
+)
+```
+
 ## Methods
 
 ### find_items — Read

--- a/py_appsheet/client.py
+++ b/py_appsheet/client.py
@@ -12,9 +12,19 @@ Some notes:
 
 
 class AppSheetClient:
-    def __init__(self, app_id, api_key):
+    def __init__(self, app_id, api_key, locale="en-US", timezone="UTC"):
+        """
+        Args:
+            app_id (str): Your AppSheet app ID.
+            api_key (str): Your AppSheet API key.
+            locale (str): Locale sent with every API request. Defaults to "en-US".
+                Use your local locale (e.g. "de-DE") if AppSheet is misinterpreting date values.
+            timezone (str): Timezone sent with every API request. Defaults to "UTC".
+        """
         self.app_id = app_id
         self.api_key = api_key
+        self.locale = locale
+        self.timezone = timezone
 
     def _make_request(self, table_name, action, payload):
         url = f"https://api.appsheet.com/api/v2/apps/{self.app_id}/tables/{table_name}/Action"
@@ -49,7 +59,7 @@ class AppSheetClient:
         Returns:
             list: A list of rows (dicts) matching the criteria. Returns an empty list if no matches.
         """
-        properties = {"Locale": "en-US", "Timezone": "UTC"}
+        properties = {"Locale": self.locale, "Timezone": self.timezone}
         if selector:
             properties["Selector"] = selector
 
@@ -90,8 +100,8 @@ class AppSheetClient:
         payload = {
             "Action": "Add",
             "Properties": {
-                "Locale": "en-US",
-                "Timezone": "UTC"
+                "Locale": self.locale,
+                "Timezone": self.timezone
             },
             "Rows": rows
         }
@@ -131,8 +141,8 @@ class AppSheetClient:
         payload = {
             "Action": "Edit",
             "Properties": {
-                "Locale": "en-US",
-                "Timezone": "UTC"
+                "Locale": self.locale,
+                "Timezone": self.timezone
             },
             "Rows": [row_data]
         }
@@ -177,8 +187,8 @@ class AppSheetClient:
         payload = {
             "Action": "Delete",
             "Properties": {
-                "Locale": "en-US",
-                "Timezone": "UTC"
+                "Locale": self.locale,
+                "Timezone": self.timezone
             },
             "Rows": [row]
         }

--- a/py_appsheet/client.py
+++ b/py_appsheet/client.py
@@ -12,7 +12,7 @@ Some notes:
 
 
 class AppSheetClient:
-    def __init__(self, app_id, api_key, locale="en-US", timezone="UTC"):
+    def __init__(self, app_id, api_key, *, locale="en-US", timezone="UTC"):
         """
         Args:
             app_id (str): Your AppSheet app ID.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,7 @@ class TestAppSheetClient(unittest.TestCase):
     def test__init__locale_tz_custom(self):
         client = AppSheetClient(app_id="test_app_id", api_key="test_api_key", locale="de-DE", timezone="WET")
         with patch.object(client, '_make_request', return_value=[]) as mock_req:
-             client.find_items("MyTable")
+            client.find_items("MyTable")
         payload = mock_req.call_args[0][2]
         self.assertEqual(payload["Properties"]["Locale"], "de-DE")
         self.assertEqual(payload["Properties"]["Timezone"], "WET")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,18 +11,18 @@ class TestAppSheetClient(unittest.TestCase):
     def test__init__locale_tz_fallback(self):
         client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
         with patch.object(client, '_make_request', return_value=[]) as mock_req:
-             client.find_items("MyTable")
+            client.find_items("MyTable")
         payload = mock_req.call_args[0][2]
         self.assertEqual(payload["Properties"]["Locale"], "en-US")
         self.assertEqual(payload["Properties"]["Timezone"], "UTC")
 
     def test__init__locale_tz_custom(self):
-        client = AppSheetClient(app_id="test_app_id", api_key="test_api_key",locale="de-DE",timezone="WET")
+        client = AppSheetClient(app_id="test_app_id", api_key="test_api_key", locale="de-DE", timezone="WET")
         with patch.object(client, '_make_request', return_value=[]) as mock_req:
              client.find_items("MyTable")
         payload = mock_req.call_args[0][2]
         self.assertEqual(payload["Properties"]["Locale"], "de-DE")
-        self.assertEqual(payload["Properties"]["Timezone"], "WET")        
+        self.assertEqual(payload["Properties"]["Timezone"], "WET")
 
     # --- find_items ---
 
@@ -103,9 +103,12 @@ class TestAppSheetClient(unittest.TestCase):
     def test_add_items(self):
         rows = [{"Serial Number Hex": "ABC123", "SKU": "SKU123"}]
         mock_response = {"status": "OK"}
-        with patch.object(self.client, '_make_request', return_value=mock_response):
+        with patch.object(self.client, '_make_request', return_value=mock_response) as mock_req:
             response = self.client.add_items("Inventory Table", rows)
+        payload = mock_req.call_args[0][2]
         self.assertEqual(response["status"], "OK")
+        self.assertEqual(payload["Properties"]["Locale"], "en-US")
+        self.assertEqual(payload["Properties"]["Timezone"], "UTC")
 
     # --- edit_item ---
 
@@ -115,9 +118,12 @@ class TestAppSheetClient(unittest.TestCase):
             "Bar Code": "some_barcode.svg",
         }
         mock_response = {"status": "OK"}
-        with patch.object(self.client, '_make_request', return_value=mock_response):
+        with patch.object(self.client, '_make_request', return_value=mock_response) as mock_req:
             response = self.client.edit_item("Inventory Table", "Serial Number Hex", row_data)
+        payload = mock_req.call_args[0][2]
         self.assertEqual(response["status"], "OK")
+        self.assertEqual(payload["Properties"]["Locale"], "en-US")
+        self.assertEqual(payload["Properties"]["Timezone"], "UTC")
 
     def test_edit_item_missing_key_column_raises(self):
         row_data = {"Bar Code": "some_barcode.svg"}
@@ -129,9 +135,12 @@ class TestAppSheetClient(unittest.TestCase):
 
     def test_delete_item(self):
         mock_response = {"status": "OK"}
-        with patch.object(self.client, '_make_request', return_value=mock_response):
+        with patch.object(self.client, '_make_request', return_value=mock_response) as mock_req:
             response = self.client.delete_item("Inventory Table", "Serial Number Hex", "ABC123")
+        payload = mock_req.call_args[0][2]
         self.assertEqual(response["status"], "OK")
+        self.assertEqual(payload["Properties"]["Locale"], "en-US")
+        self.assertEqual(payload["Properties"]["Timezone"], "UTC")
 
     def test_delete_item_composite_key(self):
         mock_response = {"status": "OK"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,22 @@ class TestAppSheetClient(unittest.TestCase):
     def setUp(self):
         self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
 
+    def test__init__locale_tz_fallback(self):
+        client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
+        with patch.object(client, '_make_request', return_value=[]) as mock_req:
+             client.find_items("MyTable")
+        payload = mock_req.call_args[0][2]
+        self.assertEqual(payload["Properties"]["Locale"], "en-US")
+        self.assertEqual(payload["Properties"]["Timezone"], "UTC")
+
+    def test__init__locale_tz_custom(self):
+        client = AppSheetClient(app_id="test_app_id", api_key="test_api_key",locale="de-DE",timezone="WET")
+        with patch.object(client, '_make_request', return_value=[]) as mock_req:
+             client.find_items("MyTable")
+        payload = mock_req.call_args[0][2]
+        self.assertEqual(payload["Properties"]["Locale"], "de-DE")
+        self.assertEqual(payload["Properties"]["Timezone"], "WET")        
+
     # --- find_items ---
 
     def test_find_items_found(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ class TestAppSheetClient(unittest.TestCase):
     def setUp(self):
         self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
 
-    def test__init__locale_tz_fallback(self):
+    def test__init__locale_tz_defaults(self):
         client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
         with patch.object(client, '_make_request', return_value=[]) as mock_req:
             client.find_items("MyTable")


### PR DESCRIPTION
Closes issue #4 

The previous version of this library defaulted to `en-US` for locale and `UTC` for TZ under the hood. Now:
- Adds `locale` and `timezone` params to AppSheetClient.__init__()`, defaulting to `en-US` and `UTC` 
- Threads through to find/add/edit/delete etc.                                                                                                         
- Additional tests add to cover default and fallback.

Fix co-created with [Claude Code](https://claude.com/claude-code) and manually tested/reviewed.