### PR TITLE
Support for added for exporting appsheet tables and their schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ htmlcov/
 .pytest_cache/
 
 appsheet_backup_export_schema_spec_v3.md
+
+# Scratch scripts
+tmp/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # py-appsheet
-A no-frills Python library for interacting with the Google AppSheet API.
+A no-frills Python library for interacting with the Google AppSheet API. Depends only on [`requests`](https://requests.readthedocs.io) — no other third-party dependencies.
 
 ## Installation
 ```
@@ -213,7 +213,7 @@ diff = diff_schemas(old_schema, new_schema)
 # -> {"added": [...], "removed": [...], "type_changed": [...], "unchanged": [...]}
 ```
 
-Works with schemas from any source (`data_inference`, `preview_scrape`, `manual`).
+Works with schemas produced by `infer_schema()` or any user-provided schema dict containing a `columns` list with `name` and `inferred_type` (or `appsheet_type`) fields.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,61 @@ client = AppSheetClient(
 )
 ```
 
+## Export & Schema Workflow
+
+Py-appsheet includes methods to help backup and export your tables and their schemas. The recommended workflow for exporting data safely:
+
+**Step 1 — Infer the schema from live data:**
+```python
+# Single table
+schema = client.infer_schema("Orders")
+
+# Multiple tables at once — returns {table_name: schema}
+schemas = client.infer_all_schemas(["Orders", "Patients", "Results"])
+```
+This fetches all rows, infers column types, and returns a schema dict with `contains_pii=False` on every column.
+
+**Step 2 — Review and mark PII columns:**
+
+Save the schema to a JSON file, edit it, and flip `contains_pii` to `true` for any columns that contain personal data. Optionally correct any type mismatches.
+
+```json
+{
+  "Orders": {
+    "columns": [
+      {"name": "patient_name", "contains_pii": true,  "inferred_type": "string"},
+      {"name": "order_ref",    "contains_pii": false, "inferred_type": "string"}
+    ]
+  }
+}
+```
+
+**Step 3 — Export using the schema:**
+```python
+import json
+
+with open("schemas.json") as f:
+    schemas = json.load(f)
+
+# Full export (emits a UserWarning if PII columns are present and not redacted)
+data, log = client.export_all_tables(["Orders", "Patients"], schemas=schemas)
+
+# De-identified export — PII columns replaced with "[REDACTED]"
+data, log = client.export_all_tables(["Orders", "Patients"], schemas=schemas, redact_pii=True)
+```
+
+See `examples/export_workflow.py` for a complete runnable example.
+
+> **Note:** Columns that are entirely blank across all rows may be omitted from the AppSheet API
+> response and will be absent from the inferred schema. If your table has always-empty columns,
+> add them manually to the schema JSON.
+
+> **Note:** Redacted values are always replaced with the string `"[REDACTED]"` regardless of the
+> column's original type (number, boolean, etc.). AppSheet returns all values as strings, so this
+> is consistent with the data format throughout.
+
+---
+
 ## Methods
 
 ### find_items — Read
@@ -106,6 +161,59 @@ response = client.delete_item("My Table", {"keycol1": "foo", "keycol2": "bar"})
 ```
 
 `delete_row()` is available as a backwards-compatible alias for `delete_item()`.
+
+### export_table — Full table export
+
+```python
+# Export all rows
+rows = client.export_table("Orders")
+
+# With schema — ensures all schema columns present, even if blank in AppSheet
+rows = client.export_table("Orders", schema=orders_schema)
+
+# De-identified — PII columns replaced with "[REDACTED]"
+rows = client.export_table("Orders", schema=orders_schema, redact_pii=True)
+```
+
+### export_all_tables — Multi-table export
+
+```python
+data, log = client.export_all_tables(
+    ["Orders", "Patients"],
+    schemas=schemas,      # dict of {table_name: schema}
+    redact_pii=True,
+)
+
+# data -> {"Orders": [...rows...], "Patients": [...rows...]}
+# log  -> {"status": "complete", "exported": [...], "failed": [...], ...}
+```
+
+Failed tables are logged and skipped — the export continues for remaining tables.
+
+### infer_schema / infer_all_schemas — Data-driven schema inference
+
+```python
+# Single table
+schema = client.infer_schema("Orders")
+
+# Pass pre-fetched rows to avoid a redundant API call
+rows = client.export_table("Orders")
+schema = client.infer_schema("Orders", rows=rows)
+
+# Multiple tables — returns {table_name: schema} ready for export_all_tables()
+schemas = client.infer_all_schemas(["Orders", "Patients", "Results"])
+```
+
+### diff_schemas — Schema change detection
+
+```python
+from py_appsheet import diff_schemas
+
+diff = diff_schemas(old_schema, new_schema)
+# -> {"added": [...], "removed": [...], "type_changed": [...], "unchanged": [...]}
+```
+
+Works with schemas from any source (`data_inference`, `preview_scrape`, `manual`).
 
 ---
 

--- a/examples/export_workflow.py
+++ b/examples/export_workflow.py
@@ -14,7 +14,7 @@ Usage:
 """
 import os
 import json
-from py_appsheet import AppSheetClient, diff_schemas
+from py_appsheet import AppSheetClient
 
 client = AppSheetClient(
     app_id=os.environ["APPSHEET_APP_ID"],

--- a/examples/export_workflow.py
+++ b/examples/export_workflow.py
@@ -52,7 +52,7 @@ def export_with_schemas():
 
     print(f"Status:    {log['status']}")
     print(f"Timestamp: {log['timestamp']}")
-    print(f"Redacted:  {log['redact_pii']}\n")
+    print(f"Redacted:  {log['redact_pii_requested']}\n")
 
     for entry in log["exported"]:
         print(f"  {entry['table']}: {entry['row_count']} rows exported")

--- a/examples/export_workflow.py
+++ b/examples/export_workflow.py
@@ -1,0 +1,69 @@
+"""
+Export workflow example.
+
+Demonstrates the recommended approach for exporting AppSheet data with
+schema-driven column normalization and optional PII redaction.
+
+Step 1: Run with INFER=true to generate schemas.json for your tables.
+Step 2: Edit schemas.json — set contains_pii=true on PII columns.
+Step 3: Run normally to export using the saved schemas.
+
+Usage:
+    INFER=true python examples/export_workflow.py   # generate schemas.json
+    python examples/export_workflow.py              # export with schemas
+"""
+import os
+import json
+from py_appsheet import AppSheetClient, diff_schemas
+
+client = AppSheetClient(
+    app_id=os.environ["APPSHEET_APP_ID"],
+    api_key=os.environ["APPSHEET_API_KEY"],
+)
+
+TABLE_NAMES = [
+    "Orders",
+    # "Patients",
+]
+
+SCHEMAS_FILE = "schemas.json"
+
+
+def infer_and_save():
+    schemas = client.infer_all_schemas(TABLE_NAMES)
+    for table, schema in schemas.items():
+        print(f"{table}: {len(schema['columns'])} columns, {schema['row_count']} rows")
+
+    with open(SCHEMAS_FILE, "w") as f:
+        json.dump(schemas, f, indent=2)
+
+    print(f"\nSchemas saved to {SCHEMAS_FILE}")
+    print("Review the file and set contains_pii=true on any PII columns, then re-run.")
+
+
+def export_with_schemas():
+    if not os.path.exists(SCHEMAS_FILE):
+        raise FileNotFoundError(f"{SCHEMAS_FILE} not found — run with INFER=true first")
+
+    with open(SCHEMAS_FILE) as f:
+        schemas = json.load(f)
+
+    data, log = client.export_all_tables(TABLE_NAMES, schemas=schemas, redact_pii=True)
+
+    print(f"Status:    {log['status']}")
+    print(f"Timestamp: {log['timestamp']}")
+    print(f"Redacted:  {log['redact_pii']}\n")
+
+    for entry in log["exported"]:
+        print(f"  {entry['table']}: {entry['row_count']} rows exported")
+
+    for entry in log["failed"]:
+        print(f"  FAILED: {entry['table']} — {entry['error']}")
+
+    return data, log
+
+
+if os.getenv("INFER"):
+    infer_and_save()
+else:
+    data, log = export_with_schemas()

--- a/py_appsheet/__init__.py
+++ b/py_appsheet/__init__.py
@@ -1,4 +1,5 @@
 from .client import AppSheetClient
 from .utils import build_composite_key, build_selector
+from .schema import diff_schemas
 
-__all__ = ["AppSheetClient", "build_composite_key", "build_selector"]
+__all__ = ["AppSheetClient", "build_composite_key", "build_selector", "diff_schemas"]

--- a/py_appsheet/client.py
+++ b/py_appsheet/client.py
@@ -1,5 +1,7 @@
 #
 import requests
+from .export import ExportMixin
+from .schema import SchemaMixin
 
 '''
 Some notes:
@@ -11,7 +13,7 @@ Some notes:
 '''
 
 
-class AppSheetClient:
+class AppSheetClient(ExportMixin, SchemaMixin):
     def __init__(self, app_id, api_key, *, locale="en-US", timezone="UTC"):
         """
         Args:

--- a/py_appsheet/export.py
+++ b/py_appsheet/export.py
@@ -1,0 +1,106 @@
+import warnings
+from datetime import datetime, timezone
+
+
+class ExportMixin:
+    def export_table(
+        self,
+        table_name: str,
+        schema: dict | None = None,
+        redact_pii: bool = False,
+    ) -> list[dict]:
+        """
+        Export all rows from the specified AppSheet table.
+
+        Args:
+            table_name (str): The name of the table to export.
+            schema (dict, optional): A schema dict (from infer_schema(), the scraper, or manual).
+                If provided, ensures every schema column is present in every row (filling None
+                for columns AppSheet omitted). Also enables PII-aware behavior.
+            redact_pii (bool): If True, replaces values in columns marked contains_pii=True
+                with "[REDACTED]". Requires schema. Defaults to False.
+
+        Returns:
+            list[dict]: All rows from the table.
+
+        Raises:
+            ValueError: If redact_pii=True but no schema is provided.
+
+        Note:
+            Redacted values are always replaced with the string "[REDACTED]" regardless
+            of the column's original type. AppSheet returns all values as strings, so
+            this is consistent with the data format throughout.
+        """
+        if redact_pii and schema is None:
+            raise ValueError("redact_pii=True requires a schema to identify PII columns.")
+
+        rows = self.find_items(table_name)
+
+        if schema is not None:
+            columns = schema.get("columns", [])
+            column_names = [col["name"] for col in columns]
+            pii_columns = {col["name"] for col in columns if col.get("contains_pii", False)}
+
+            if not redact_pii and pii_columns:
+                warnings.warn(
+                    f"Export of '{table_name}' includes columns marked contains_pii=True: "
+                    f"{sorted(pii_columns)}. Pass redact_pii=True to redact them.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+            normalized = []
+            for row in rows:
+                normalized_row = {col: row.get(col, None) for col in column_names}
+                if redact_pii:
+                    for col in pii_columns:
+                        normalized_row[col] = "[REDACTED]"
+                normalized.append(normalized_row)
+            rows = normalized
+
+        return rows
+
+    def export_all_tables(
+        self,
+        table_names: list[str],
+        schemas: dict[str, dict] | None = None,
+        redact_pii: bool = False,
+    ) -> tuple[dict[str, list[dict]], dict]:
+        """
+        Export multiple AppSheet tables.
+
+        Args:
+            table_names (list[str]): Names of tables to export.
+            schemas (dict[str, dict], optional): A dict mapping table names to schema dicts.
+                Tables not present in schemas are exported without a schema.
+            redact_pii (bool): If True, redacts PII columns in all tables that have a schema.
+                Defaults to False.
+
+        Returns:
+            tuple: (data, log)
+                data (dict[str, list[dict]]): Successfully exported tables keyed by table name.
+                log (dict): Export summary with status, timestamps, row counts, and any failures.
+                    Status is "complete" if all tables succeeded, "partial" if any failed.
+        """
+        data = {}
+        exported = []
+        failed = []
+
+        for table_name in table_names:
+            schema = schemas.get(table_name) if schemas is not None else None
+            try:
+                rows = self.export_table(table_name, schema=schema, redact_pii=redact_pii)
+                data[table_name] = rows
+                exported.append({"table": table_name, "row_count": len(rows)})
+            except Exception as e:
+                failed.append({"table": table_name, "error": str(e)})
+
+        log = {
+            "status": "complete" if not failed else "partial",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "redact_pii": redact_pii,
+            "exported": exported,
+            "failed": failed,
+        }
+
+        return data, log

--- a/py_appsheet/export.py
+++ b/py_appsheet/export.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from datetime import datetime, timezone
 
@@ -88,8 +90,9 @@ class ExportMixin:
 
         for table_name in table_names:
             schema = schemas.get(table_name) if schemas is not None else None
+            table_redact_pii = redact_pii and schema is not None
             try:
-                rows = self.export_table(table_name, schema=schema, redact_pii=redact_pii)
+                rows = self.export_table(table_name, schema=schema, redact_pii=table_redact_pii)
                 data[table_name] = rows
                 exported.append({"table": table_name, "row_count": len(rows)})
             except Exception as e:

--- a/py_appsheet/export.py
+++ b/py_appsheet/export.py
@@ -16,9 +16,10 @@ class ExportMixin:
 
         Args:
             table_name (str): The name of the table to export.
-            schema (dict, optional): A schema dict (from infer_schema(), the scraper, or manual).
-                If provided, ensures every schema column is present in every row (filling None
-                for columns AppSheet omitted). Also enables PII-aware behavior.
+            schema (dict, optional): A schema dict, such as the output of infer_schema()
+                or any user-provided schema dict with a "columns" list.
+                If provided, ensures every schema column is present in every row (filling
+                None for columns AppSheet omitted). Also enables PII-aware behavior.
             redact_pii (bool): If True, replaces values in columns marked contains_pii=True
                 with "[REDACTED]". Requires schema. Defaults to False.
 
@@ -51,12 +52,27 @@ class ExportMixin:
                     stacklevel=2,
                 )
 
+            extra_columns = [
+                col for col in (set(rows[0].keys()) if rows else set())
+                if col not in set(column_names)
+            ]
+            if extra_columns:
+                warnings.warn(
+                    f"Export of '{table_name}' returned columns not present in schema: "
+                    f"{sorted(extra_columns)}. They will be included after schema columns. "
+                    "Update the schema to suppress this warning.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
             normalized = []
             for row in rows:
                 normalized_row = {col: row.get(col, None) for col in column_names}
                 if redact_pii:
                     for col in pii_columns:
                         normalized_row[col] = "[REDACTED]"
+                for col in extra_columns:
+                    normalized_row[col] = row.get(col)
                 normalized.append(normalized_row)
             rows = normalized
 
@@ -88,9 +104,23 @@ class ExportMixin:
         exported = []
         failed = []
 
+        redacted_tables = []
+        unredacted_tables = []
+
         for table_name in table_names:
             schema = schemas.get(table_name) if schemas is not None else None
             table_redact_pii = redact_pii and schema is not None
+            if redact_pii and not table_redact_pii:
+                warnings.warn(
+                    f"redact_pii=True was requested but '{table_name}' has no schema — "
+                    "it will be exported without redaction.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                unredacted_tables.append(table_name)
+            elif table_redact_pii:
+                redacted_tables.append(table_name)
+
             try:
                 rows = self.export_table(table_name, schema=schema, redact_pii=table_redact_pii)
                 data[table_name] = rows
@@ -101,7 +131,9 @@ class ExportMixin:
         log = {
             "status": "complete" if not failed else "partial",
             "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "redact_pii": redact_pii,
+            "redact_pii_requested": redact_pii,
+            "redacted_tables": redacted_tables,
+            "unredacted_tables": unredacted_tables,
             "exported": exported,
             "failed": failed,
         }

--- a/py_appsheet/export.py
+++ b/py_appsheet/export.py
@@ -52,10 +52,14 @@ class ExportMixin:
                     stacklevel=2,
                 )
 
-            extra_columns = [
-                col for col in (set(rows[0].keys()) if rows else set())
-                if col not in set(column_names)
-            ]
+            schema_column_set = set(column_names)
+            extra_columns = []
+            seen_extra = set()
+            for row in rows:
+                for col in row:
+                    if col not in schema_column_set and col not in seen_extra:
+                        extra_columns.append(col)
+                        seen_extra.add(col)
             if extra_columns:
                 warnings.warn(
                     f"Export of '{table_name}' returned columns not present in schema: "
@@ -117,14 +121,15 @@ class ExportMixin:
                     UserWarning,
                     stacklevel=2,
                 )
-                unredacted_tables.append(table_name)
-            elif table_redact_pii:
-                redacted_tables.append(table_name)
 
             try:
                 rows = self.export_table(table_name, schema=schema, redact_pii=table_redact_pii)
                 data[table_name] = rows
                 exported.append({"table": table_name, "row_count": len(rows)})
+                if redact_pii and not table_redact_pii:
+                    unredacted_tables.append(table_name)
+                elif table_redact_pii:
+                    redacted_tables.append(table_name)
             except Exception as e:
                 failed.append({"table": table_name, "error": str(e)})
 

--- a/py_appsheet/schema.py
+++ b/py_appsheet/schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
 
 

--- a/py_appsheet/schema.py
+++ b/py_appsheet/schema.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timezone
+
+
+def _infer_type(values: list) -> str:
+    non_null = [v for v in values if v is not None and v != ""]
+    if not non_null:
+        return "unknown"
+    if _all_match(non_null, _is_boolean):
+        return "boolean"
+    if _all_match(non_null, _is_integer):
+        return "integer"
+    if _all_match(non_null, _is_float):
+        return "number"
+    if _all_match(non_null, _is_datetime):
+        return "datetime"
+    return "string"
+
+
+def _all_match(values: list, predicate) -> bool:
+    return all(predicate(v) for v in values)
+
+
+def _is_boolean(value: str) -> bool:
+    return str(value).strip().lower() in ("true", "false")
+
+
+def _is_integer(value: str) -> bool:
+    try:
+        int(str(value).strip())
+        return True
+    except ValueError:
+        return False
+
+
+def _is_float(value: str) -> bool:
+    try:
+        float(str(value).strip())
+        return True
+    except ValueError:
+        return False
+
+
+def _is_datetime(value: str) -> bool:
+    formats = (
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d",
+        "%m/%d/%Y",
+        "%m/%d/%Y %H:%M:%S",
+    )
+    s = str(value).strip().rstrip("Z")
+    for fmt in formats:
+        try:
+            datetime.strptime(s, fmt.rstrip("Z"))
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+class SchemaMixin:
+    def infer_all_schemas(self, table_names: list[str]) -> dict[str, dict]:
+        """
+        Infer schemas for multiple tables.
+
+        Args:
+            table_names (list[str]): Names of tables to infer schemas for.
+
+        Returns:
+            dict[str, dict]: Schema dicts keyed by table name, ready to pass
+                to export_all_tables(schemas=...).
+        """
+        return {table: self.infer_schema(table) for table in table_names}
+
+    def infer_schema(
+        self,
+        table_name: str,
+        rows: list[dict] | None = None,
+    ) -> dict:
+        """
+        Infer a schema for the specified table from live API data.
+
+        Args:
+            table_name (str): The name of the table.
+            rows (list[dict], optional): Pre-fetched rows to infer from. If None,
+                fetches internally via export_table(). Pass pre-fetched rows to
+                avoid a redundant API call when you already have the data.
+
+        Returns:
+            dict: A schema dict with source "data_inference". The contains_pii field
+                defaults to False for all columns — set it manually as needed.
+        """
+        if rows is None:
+            rows = self.export_table(table_name)
+
+        column_names = []
+        seen = set()
+        for row in rows:
+            for col in row:
+                if col not in seen:
+                    column_names.append(col)
+                    seen.add(col)
+
+        columns = []
+        for col in column_names:
+            values = [row.get(col) for row in rows]
+            nullable = any(v is None or v == "" for v in values)
+            columns.append({
+                "name": col,
+                "contains_pii": False,
+                "inferred_type": _infer_type(values),
+                "nullable": nullable,
+            })
+
+        return {
+            "table_name": table_name,
+            "appsheet_app_id": self.app_id,
+            "captured_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "source": "data_inference",
+            "row_count": len(rows),
+            "columns": columns,
+        }
+
+
+def diff_schemas(old_schema: dict, new_schema: dict) -> dict:
+    """
+    Compare two schema dicts and return a summary of changes.
+
+    Works with any schema source (data_inference, preview_scrape, manual).
+    Uses inferred_type if present, otherwise appsheet_type for type comparison.
+
+    Args:
+        old_schema (dict): The previous schema.
+        new_schema (dict): The current schema.
+
+    Returns:
+        dict: Keys: added, removed, type_changed, unchanged — each a list.
+    """
+    def col_map(schema):
+        return {
+            col["name"]: col.get("inferred_type") or col.get("appsheet_type")
+            for col in schema.get("columns", [])
+        }
+
+    old = col_map(old_schema)
+    new = col_map(new_schema)
+
+    added = [name for name in new if name not in old]
+    removed = [name for name in old if name not in new]
+    type_changed = [
+        {"column": name, "old_type": old[name], "new_type": new[name]}
+        for name in old
+        if name in new and old[name] != new[name]
+    ]
+    unchanged = [name for name in old if name in new and old[name] == new[name]]
+
+    return {
+        "added": added,
+        "removed": removed,
+        "type_changed": type_changed,
+        "unchanged": unchanged,
+    }

--- a/py_appsheet/schema.py
+++ b/py_appsheet/schema.py
@@ -130,8 +130,9 @@ def diff_schemas(old_schema: dict, new_schema: dict) -> dict:
     """
     Compare two schema dicts and return a summary of changes.
 
-    Works with any schema source (data_inference, preview_scrape, manual).
-    Uses inferred_type if present, otherwise appsheet_type for type comparison.
+    Works with any schema dict that provides a ``columns`` list of column
+    definitions. Each column should include ``name`` and either
+    ``inferred_type`` or ``appsheet_type`` for type comparison.
 
     Args:
         old_schema (dict): The previous schema.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "requests>=2.0.0",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -141,6 +141,20 @@ class TestExportAllTables(unittest.TestCase):
             )
         self.assertEqual(data["TestTable"][0]["name"], "[REDACTED]")
 
+    def test_export_all_tables_redact_pii_skips_tables_without_schema(self):
+        schemas = {"TableA": SCHEMA_WITH_PII}
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            data, log = self.client.export_all_tables(
+                ["TableA", "TableB"],
+                schemas=schemas,
+                redact_pii=True,
+            )
+        self.assertIn("TableA", data)
+        self.assertIn("TableB", data)
+        self.assertEqual(data["TableA"][0]["name"], "[REDACTED]")
+        self.assertNotEqual(data["TableB"][0]["name"], "[REDACTED]")
+        self.assertEqual(log["status"], "complete")
+
     def test_export_all_tables_redact_pii_in_log(self):
         with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
             _, log = self.client.export_all_tables(["TestTable"], redact_pii=True)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -69,6 +69,17 @@ class TestExportTable(unittest.TestCase):
             self.assertEqual(row["email"], "[REDACTED]")
             self.assertNotEqual(row["score"], "[REDACTED]")
 
+    def test_export_table_preserves_extra_columns_not_in_schema(self):
+        rows_with_extra = [{"name": "Alice", "email": "a@example.com", "score": "42", "new_col": "surprise"}]
+        with patch.object(self.client, 'find_items', return_value=rows_with_extra):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = self.client.export_table("TestTable", schema=SCHEMA_NO_PII)
+        self.assertIn("new_col", result[0])
+        self.assertEqual(result[0]["new_col"], "surprise")
+        self.assertEqual(len(caught), 1)
+        self.assertIn("not present in schema", str(caught[0].message))
+
     def test_export_table_redact_pii_without_schema_raises(self):
         with self.assertRaises(ValueError):
             self.client.export_table("TestTable", redact_pii=True)
@@ -157,8 +168,21 @@ class TestExportAllTables(unittest.TestCase):
 
     def test_export_all_tables_redact_pii_in_log(self):
         with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
-            _, log = self.client.export_all_tables(["TestTable"], redact_pii=True)
-        self.assertTrue(log["redact_pii"])
+            _, log = self.client.export_all_tables(
+                ["TestTable"], schemas={"TestTable": SCHEMA_WITH_PII}, redact_pii=True
+            )
+        self.assertTrue(log["redact_pii_requested"])
+        self.assertIn("TestTable", log["redacted_tables"])
+        self.assertEqual(log["unredacted_tables"], [])
+
+    def test_export_all_tables_warns_and_logs_unredacted_tables(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _, log = self.client.export_all_tables(["TestTable"], redact_pii=True)
+        self.assertIn("TestTable", log["unredacted_tables"])
+        self.assertEqual(log["redacted_tables"], [])
+        self.assertTrue(any("without redaction" in str(w.message) for w in caught))
 
     def test_export_all_tables_log_has_timestamp(self):
         with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,157 @@
+import unittest
+import warnings
+from unittest.mock import patch
+from py_appsheet.client import AppSheetClient
+
+
+MOCK_ROWS = [
+    {"name": "Alice", "email": "alice@example.com", "score": "42"},
+    {"name": "Bob",   "email": "bob@example.com",   "score": "17"},
+]
+
+SCHEMA_WITH_PII = {
+    "table_name": "TestTable",
+    "source": "manual",
+    "columns": [
+        {"name": "name",  "contains_pii": True},
+        {"name": "email", "contains_pii": True},
+        {"name": "score", "contains_pii": False},
+    ],
+}
+
+SCHEMA_NO_PII = {
+    "table_name": "TestTable",
+    "source": "manual",
+    "columns": [
+        {"name": "name",  "contains_pii": False},
+        {"name": "email", "contains_pii": False},
+        {"name": "score", "contains_pii": False},
+    ],
+}
+
+SCHEMA_WITH_EXTRA_COLUMN = {
+    "table_name": "TestTable",
+    "source": "manual",
+    "columns": [
+        {"name": "name",   "contains_pii": False},
+        {"name": "email",  "contains_pii": False},
+        {"name": "score",  "contains_pii": False},
+        {"name": "absent", "contains_pii": False},
+    ],
+}
+
+
+class TestExportTable(unittest.TestCase):
+    def setUp(self):
+        self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
+
+    def test_export_table_no_schema_returns_raw_rows(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            result = self.client.export_table("TestTable")
+        self.assertEqual(result, MOCK_ROWS)
+
+    def test_export_table_with_schema_normalizes_columns(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            result = self.client.export_table("TestTable", schema=SCHEMA_WITH_EXTRA_COLUMN)
+        self.assertIn("absent", result[0])
+        self.assertIsNone(result[0]["absent"])
+
+    def test_export_table_column_order_matches_schema(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            result = self.client.export_table("TestTable", schema=SCHEMA_NO_PII)
+        self.assertEqual(list(result[0].keys()), ["name", "email", "score"])
+
+    def test_export_table_redact_pii_replaces_values(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            result = self.client.export_table("TestTable", schema=SCHEMA_WITH_PII, redact_pii=True)
+        for row in result:
+            self.assertEqual(row["name"], "[REDACTED]")
+            self.assertEqual(row["email"], "[REDACTED]")
+            self.assertNotEqual(row["score"], "[REDACTED]")
+
+    def test_export_table_redact_pii_without_schema_raises(self):
+        with self.assertRaises(ValueError):
+            self.client.export_table("TestTable", redact_pii=True)
+
+    def test_export_table_warns_when_pii_not_redacted(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                self.client.export_table("TestTable", schema=SCHEMA_WITH_PII, redact_pii=False)
+        self.assertEqual(len(caught), 1)
+        self.assertIn("contains_pii=True", str(caught[0].message))
+
+    def test_export_table_no_warning_when_no_pii_columns(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                self.client.export_table("TestTable", schema=SCHEMA_NO_PII, redact_pii=False)
+        self.assertEqual(len(caught), 0)
+
+    def test_export_table_no_warning_when_no_schema(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                self.client.export_table("TestTable")
+        self.assertEqual(len(caught), 0)
+
+
+class TestExportAllTables(unittest.TestCase):
+    def setUp(self):
+        self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
+
+    def test_export_all_tables_returns_data_and_log(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            data, log = self.client.export_all_tables(["TestTable"])
+        self.assertIn("TestTable", data)
+        self.assertIn("status", log)
+
+    def test_export_all_tables_complete_status(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            _, log = self.client.export_all_tables(["TestTable"])
+        self.assertEqual(log["status"], "complete")
+        self.assertEqual(len(log["exported"]), 1)
+        self.assertEqual(len(log["failed"]), 0)
+
+    def test_export_all_tables_partial_status_on_failure(self):
+        def fail_one(table_name, **kwargs):
+            if table_name == "BadTable":
+                raise Exception("status 500")
+            return MOCK_ROWS
+
+        with patch.object(self.client, 'find_items', side_effect=fail_one):
+            data, log = self.client.export_all_tables(["TestTable", "BadTable"])
+
+        self.assertIn("TestTable", data)
+        self.assertNotIn("BadTable", data)
+        self.assertEqual(log["status"], "partial")
+        self.assertEqual(len(log["failed"]), 1)
+        self.assertEqual(log["failed"][0]["table"], "BadTable")
+
+    def test_export_all_tables_log_row_counts(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            _, log = self.client.export_all_tables(["TestTable"])
+        self.assertEqual(log["exported"][0]["row_count"], 2)
+
+    def test_export_all_tables_uses_schema_per_table(self):
+        schemas = {"TestTable": SCHEMA_WITH_PII}
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            data, _ = self.client.export_all_tables(
+                ["TestTable"], schemas=schemas, redact_pii=True
+            )
+        self.assertEqual(data["TestTable"][0]["name"], "[REDACTED]")
+
+    def test_export_all_tables_redact_pii_in_log(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            _, log = self.client.export_all_tables(["TestTable"], redact_pii=True)
+        self.assertTrue(log["redact_pii"])
+
+    def test_export_all_tables_log_has_timestamp(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            _, log = self.client.export_all_tables(["TestTable"])
+        self.assertIn("timestamp", log)
+        self.assertTrue(log["timestamp"].endswith("Z"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,6 +16,7 @@ composite key tests will fail.
 """
 import pytest
 from py_appsheet.utils import build_composite_key, build_selector
+from py_appsheet.schema import diff_schemas
 
 EXAMPLE_TABLE = "example_table"
 DUAL_KEY_TABLE = "dual_key_table"
@@ -122,6 +123,131 @@ class TestExampleTable:
         client.delete_row(EXAMPLE_TABLE, "Title Example", TEST_TITLE)
         results = client.find_items(EXAMPLE_TABLE, TEST_TITLE, target_column="Title Example")
         assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# export tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestExport:
+
+    def test_export_table_returns_list(self, client):
+        """export_table returns a non-empty list of dicts."""
+        rows = client.export_table(EXAMPLE_TABLE)
+        assert isinstance(rows, list)
+        assert len(rows) >= 1
+        assert isinstance(rows[0], dict)
+
+    def test_export_table_with_schema_normalizes_columns(self, client):
+        """export_table with a schema ensures all schema columns are present in every row."""
+        schema = {
+            "table_name": EXAMPLE_TABLE,
+            "source": "manual",
+            "columns": [
+                {"name": "Title Example", "contains_pii": False},
+                {"name": "Assignee",      "contains_pii": False},
+                {"name": "Status",        "contains_pii": False},
+                {"name": "Another Column","contains_pii": False},
+            ],
+        }
+        rows = client.export_table(EXAMPLE_TABLE, schema=schema)
+        for row in rows:
+            assert "Title Example" in row
+            assert "Assignee" in row
+            assert "Status" in row
+            assert "Another Column" in row
+
+    def test_export_table_redact_pii(self, client):
+        """export_table with redact_pii=True replaces PII column values with [REDACTED]."""
+        schema = {
+            "table_name": EXAMPLE_TABLE,
+            "source": "manual",
+            "columns": [
+                {"name": "Title Example", "contains_pii": True},
+                {"name": "Assignee",      "contains_pii": False},
+                {"name": "Status",        "contains_pii": False},
+                {"name": "Another Column","contains_pii": False},
+            ],
+        }
+        rows = client.export_table(EXAMPLE_TABLE, schema=schema, redact_pii=True)
+        for row in rows:
+            assert row["Title Example"] == "[REDACTED]"
+            assert row["Assignee"] != "[REDACTED]"
+
+    def test_export_all_tables_returns_data_and_log(self, client):
+        """export_all_tables returns data dict and a complete log."""
+        data, log = client.export_all_tables([EXAMPLE_TABLE])
+        assert EXAMPLE_TABLE in data
+        assert isinstance(data[EXAMPLE_TABLE], list)
+        assert log["status"] == "complete"
+        assert len(log["exported"]) == 1
+        assert len(log["failed"]) == 0
+
+    def test_export_all_tables_partial_on_bad_table(self, client):
+        """export_all_tables logs failures for non-existent tables and continues."""
+        data, log = client.export_all_tables([EXAMPLE_TABLE, "nonexistent_table_xyz"])
+        assert EXAMPLE_TABLE in data
+        assert log["status"] == "partial"
+        assert any(f["table"] == "nonexistent_table_xyz" for f in log["failed"])
+
+
+# ---------------------------------------------------------------------------
+# schema tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestSchema:
+
+    def test_infer_schema_returns_expected_structure(self, client):
+        """infer_schema returns a valid schema dict with required top-level keys."""
+        schema = client.infer_schema(EXAMPLE_TABLE)
+        assert schema["table_name"] == EXAMPLE_TABLE
+        assert schema["source"] == "data_inference"
+        assert schema["appsheet_app_id"] is not None
+        assert isinstance(schema["row_count"], int)
+        assert isinstance(schema["columns"], list)
+        assert len(schema["columns"]) >= 1
+
+    def test_infer_schema_column_structure(self, client):
+        """Each column in the inferred schema has required fields."""
+        schema = client.infer_schema(EXAMPLE_TABLE)
+        for col in schema["columns"]:
+            assert "name" in col
+            assert "inferred_type" in col
+            assert "nullable" in col
+            assert "contains_pii" in col
+            assert col["contains_pii"] is False
+
+    def test_infer_schema_known_columns_present(self, client):
+        """infer_schema captures the known columns of example_table."""
+        schema = client.infer_schema(EXAMPLE_TABLE)
+        names = [col["name"] for col in schema["columns"]]
+        assert "Title Example" in names
+
+    def test_infer_schema_uses_pre_fetched_rows(self, client):
+        """infer_schema accepts pre-fetched rows and does not make an extra API call."""
+        rows = client.export_table(EXAMPLE_TABLE)
+        schema = client.infer_schema(EXAMPLE_TABLE, rows=rows)
+        assert schema["row_count"] == len(rows)
+
+    def test_diff_schemas_no_change(self, client):
+        """diff_schemas reports no changes when the same schema is compared to itself."""
+        schema = client.infer_schema(EXAMPLE_TABLE)
+        diff = diff_schemas(schema, schema)
+        assert diff["added"] == []
+        assert diff["removed"] == []
+        assert diff["type_changed"] == []
+        assert len(diff["unchanged"]) == len(schema["columns"])
+
+    def test_diff_schemas_detects_added_column(self, client):
+        """diff_schemas correctly identifies a newly added column."""
+        schema = client.infer_schema(EXAMPLE_TABLE)
+        new_schema = {**schema, "columns": schema["columns"] + [
+            {"name": "new_col", "inferred_type": "string", "contains_pii": False, "nullable": True}
+        ]}
+        diff = diff_schemas(schema, new_schema)
+        assert "new_col" in diff["added"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,190 @@
+import unittest
+from unittest.mock import patch
+from py_appsheet.client import AppSheetClient
+from py_appsheet.schema import diff_schemas
+
+
+MOCK_ROWS = [
+    {"id": "1", "name": "Alice", "score": "42",   "active": "true",  "created": "2024-01-15"},
+    {"id": "2", "name": "Bob",   "score": "17",   "active": "false", "created": "2024-03-22"},
+    {"id": "3", "name": "Carol", "score": "3.14", "active": "true",  "created": "2024-06-01"},
+]
+
+MOCK_ROWS_WITH_BLANKS = [
+    {"id": "1", "name": "Alice", "notes": ""},
+    {"id": "2", "name": "Bob",   "notes": None},
+]
+
+
+class TestInferSchema(unittest.TestCase):
+    def setUp(self):
+        self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
+
+    def _infer(self, rows=None):
+        with patch.object(self.client, 'find_items', return_value=rows or MOCK_ROWS):
+            return self.client.infer_schema("TestTable")
+
+    def test_returns_correct_table_name(self):
+        schema = self._infer()
+        self.assertEqual(schema["table_name"], "TestTable")
+
+    def test_returns_correct_app_id(self):
+        schema = self._infer()
+        self.assertEqual(schema["appsheet_app_id"], "test_app_id")
+
+    def test_source_is_data_inference(self):
+        schema = self._infer()
+        self.assertEqual(schema["source"], "data_inference")
+
+    def test_row_count(self):
+        schema = self._infer()
+        self.assertEqual(schema["row_count"], 3)
+
+    def test_captured_at_present(self):
+        schema = self._infer()
+        self.assertIn("captured_at", schema)
+        self.assertTrue(schema["captured_at"].endswith("Z"))
+
+    def test_column_names(self):
+        schema = self._infer()
+        names = [col["name"] for col in schema["columns"]]
+        self.assertIn("id", names)
+        self.assertIn("name", names)
+        self.assertIn("score", names)
+        self.assertIn("active", names)
+        self.assertIn("created", names)
+
+    def test_contains_pii_defaults_false(self):
+        schema = self._infer()
+        for col in schema["columns"]:
+            self.assertFalse(col["contains_pii"])
+
+    def test_infers_integer_type(self):
+        rows = [{"val": "1"}, {"val": "2"}, {"val": "42"}]
+        schema = self._infer(rows)
+        col = next(c for c in schema["columns"] if c["name"] == "val")
+        self.assertEqual(col["inferred_type"], "integer")
+
+    def test_infers_number_type(self):
+        rows = [{"val": "3.14"}, {"val": "2.71"}, {"val": "1.0"}]
+        schema = self._infer(rows)
+        col = next(c for c in schema["columns"] if c["name"] == "val")
+        self.assertEqual(col["inferred_type"], "number")
+
+    def test_infers_boolean_type(self):
+        rows = [{"val": "true"}, {"val": "false"}, {"val": "True"}]
+        schema = self._infer(rows)
+        col = next(c for c in schema["columns"] if c["name"] == "val")
+        self.assertEqual(col["inferred_type"], "boolean")
+
+    def test_infers_datetime_type(self):
+        rows = [{"val": "2024-01-15"}, {"val": "2024-03-22"}]
+        schema = self._infer(rows)
+        col = next(c for c in schema["columns"] if c["name"] == "val")
+        self.assertEqual(col["inferred_type"], "datetime")
+
+    def test_infers_string_type(self):
+        rows = [{"val": "hello"}, {"val": "world"}]
+        schema = self._infer(rows)
+        col = next(c for c in schema["columns"] if c["name"] == "val")
+        self.assertEqual(col["inferred_type"], "string")
+
+    def test_infers_unknown_for_all_blank(self):
+        rows = [{"val": ""}, {"val": None}]
+        schema = self._infer(rows)
+        col = next(c for c in schema["columns"] if c["name"] == "val")
+        self.assertEqual(col["inferred_type"], "unknown")
+
+    def test_nullable_true_when_blank_present(self):
+        schema = self._infer(MOCK_ROWS_WITH_BLANKS)
+        col = next(c for c in schema["columns"] if c["name"] == "notes")
+        self.assertTrue(col["nullable"])
+
+    def test_nullable_false_when_no_blanks(self):
+        schema = self._infer(MOCK_ROWS)
+        col = next(c for c in schema["columns"] if c["name"] == "id")
+        self.assertFalse(col["nullable"])
+
+    def test_uses_pre_fetched_rows(self):
+        with patch.object(self.client, 'find_items') as mock_find:
+            self.client.infer_schema("TestTable", rows=MOCK_ROWS)
+        mock_find.assert_not_called()
+
+    def test_fetches_internally_when_no_rows(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS) as mock_find:
+            self.client.infer_schema("TestTable")
+        mock_find.assert_called_once()
+
+
+class TestInferAllSchemas(unittest.TestCase):
+    def setUp(self):
+        self.client = AppSheetClient(app_id="test_app_id", api_key="test_api_key")
+
+    def test_infer_all_schemas_returns_dict_keyed_by_table(self):
+        with patch.object(self.client, 'find_items', return_value=MOCK_ROWS):
+            schemas = self.client.infer_all_schemas(["TableA", "TableB"])
+        self.assertIn("TableA", schemas)
+        self.assertIn("TableB", schemas)
+        self.assertEqual(schemas["TableA"]["table_name"], "TableA")
+        self.assertEqual(schemas["TableB"]["table_name"], "TableB")
+
+    def test_infer_all_schemas_empty_list(self):
+        schemas = self.client.infer_all_schemas([])
+        self.assertEqual(schemas, {})
+
+
+class TestDiffSchemas(unittest.TestCase):
+    def _schema(self, columns):
+        return {
+            "table_name": "T",
+            "source": "manual",
+            "columns": columns,
+        }
+
+    def test_no_changes(self):
+        schema = self._schema([
+            {"name": "id", "inferred_type": "integer"},
+            {"name": "name", "inferred_type": "string"},
+        ])
+        diff = diff_schemas(schema, schema)
+        self.assertEqual(diff["added"], [])
+        self.assertEqual(diff["removed"], [])
+        self.assertEqual(diff["type_changed"], [])
+        self.assertEqual(sorted(diff["unchanged"]), ["id", "name"])
+
+    def test_detects_added_column(self):
+        old = self._schema([{"name": "id", "inferred_type": "integer"}])
+        new = self._schema([
+            {"name": "id", "inferred_type": "integer"},
+            {"name": "email", "inferred_type": "string"},
+        ])
+        diff = diff_schemas(old, new)
+        self.assertIn("email", diff["added"])
+
+    def test_detects_removed_column(self):
+        old = self._schema([
+            {"name": "id", "inferred_type": "integer"},
+            {"name": "email", "inferred_type": "string"},
+        ])
+        new = self._schema([{"name": "id", "inferred_type": "integer"}])
+        diff = diff_schemas(old, new)
+        self.assertIn("email", diff["removed"])
+
+    def test_detects_type_change(self):
+        old = self._schema([{"name": "score", "inferred_type": "string"}])
+        new = self._schema([{"name": "score", "inferred_type": "integer"}])
+        diff = diff_schemas(old, new)
+        self.assertEqual(len(diff["type_changed"]), 1)
+        self.assertEqual(diff["type_changed"][0]["column"], "score")
+        self.assertEqual(diff["type_changed"][0]["old_type"], "string")
+        self.assertEqual(diff["type_changed"][0]["new_type"], "integer")
+
+    def test_works_with_appsheet_type(self):
+        old = self._schema([{"name": "col", "appsheet_type": "Text"}])
+        new = self._schema([{"name": "col", "appsheet_type": "DateTime"}])
+        diff = diff_schemas(old, new)
+        self.assertEqual(len(diff["type_changed"]), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit enables Appsheet tables to be exported. Support for inferring schemas from exported tables is supported. These can be saved and modified by the user to clean up as needed. There is also support to mark columns as PII and redact on export. Cells with that are redacted have their values replaced with "[REDACTED]" -- note, this is includes columns that may be non-String types, so exports can be mixed.